### PR TITLE
Hotfix fix close poll option

### DIFF
--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Feed Posts/Protocols/Handler/AmityPostHeaderProtocolHandler.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Feed Posts/Protocols/Handler/AmityPostHeaderProtocolHandler.swift
@@ -85,6 +85,7 @@ final class AmityPostHeaderProtocolHandler: AmityPostHeaderDelegate {
         if post.isOwner {
             switch post.dataTypeInternal {
             case .poll:
+                print("AmityPostHeader", post.poll?.status)
                 let closePoll = TextItemOption(title: AmityLocalizedStringSet.Poll.Option.closeTitle.localizedString) { [weak self] in
                     guard let strongSelf = self else { return }
                     let cancel = AmityAlertController.Action.cancel(style: .default, handler: nil)
@@ -103,7 +104,8 @@ final class AmityPostHeaderProtocolHandler: AmityPostHeaderDelegate {
                     AmityAlertController.present(title: AmityLocalizedStringSet.Poll.Option.alertDeleteTitle.localizedString, message: AmityLocalizedStringSet.Poll.Option.alertDeleteDesc.localizedString, actions: [cancel, delete], from: viewController)
                 }
                 
-                contentView.configure(items: [closePoll, deletePoll], selectedItem: nil)
+                let items = (post.poll?.isClosed ?? false) ? [deletePoll] : [closePoll, deletePoll]
+                contentView.configure(items: items, selectedItem: nil)
                 
             case .file, .image, .text, .video, .unknown:
                 contentView.configure(items: [editOption, deleteOption], selectedItem: nil)

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Feed Posts/Protocols/Handler/AmityPostHeaderProtocolHandler.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Feed Posts/Protocols/Handler/AmityPostHeaderProtocolHandler.swift
@@ -85,7 +85,6 @@ final class AmityPostHeaderProtocolHandler: AmityPostHeaderDelegate {
         if post.isOwner {
             switch post.dataTypeInternal {
             case .poll:
-                print("AmityPostHeader", post.poll?.status)
                 let closePoll = TextItemOption(title: AmityLocalizedStringSet.Poll.Option.closeTitle.localizedString) { [weak self] in
                     guard let strongSelf = self else { return }
                     let cancel = AmityAlertController.Action.cancel(style: .default, handler: nil)

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Feed Posts/Scenes/Post Detail/ViewController/AmityPostDetailViewController.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Feed Posts/Scenes/Post Detail/ViewController/AmityPostDetailViewController.swift
@@ -200,7 +200,8 @@ open class AmityPostDetailViewController: AmityViewController {
                     AmityAlertController.present(title: AmityLocalizedStringSet.Poll.Option.alertDeleteTitle.localizedString, message: AmityLocalizedStringSet.Poll.Option.alertDeleteDesc.localizedString, actions: [cancel, delete], from: strongSelf)
                 }
                 
-                contentView.configure(items: [closePoll, deletePoll], selectedItem: nil)
+                let items = (post.poll?.isClosed ?? false) ? [deletePoll] : [closePoll, deletePoll]
+                contentView.configure(items: items, selectedItem: nil)
             case .file, .image, .text, .video, .unknown:
                 contentView.configure(items: [editOption, deleteOption], selectedItem: nil)
             case .liveStream:


### PR DESCRIPTION
## Summary

Removed close poll option from post's action menu after poll is finished. 

## Changes Made

Code changes in 
- AmityPostHeaderProtocolHandler.swift
- AmityPostDetailViewController.swift

## Impact

- No impact

## Testing

1. Create a poll
2. Vote any poll
3. Close the poll
4. Click post's setting

## Related Issues

https://ekoapp.atlassian.net/browse/ASC-11408

## Targeted Fix Version
v2.35.0

## Checklist

Please check the following before submitting this pull request:

- [x] All tests pass successfully
- [x] Code adheres to the company's coding standards and best practices
- [ ] Documentation has been updated (if applicable)
- [ ] Code has been reviewed by at least one other Ninja or senior engineer
